### PR TITLE
Changed constructor execution order to avoid calling getClients() on null

### DIFF
--- a/bundle/Command/TranslateContentCommand.php
+++ b/bundle/Command/TranslateContentCommand.php
@@ -45,13 +45,13 @@ final class TranslateContentCommand extends Command
         PermissionResolver $permissionResolver,
         UserService $userService
     ) {
-        parent::__construct();
-
         $this->clientProvider = $clientProvider;
         $this->translator = $translator;
         $this->contentService = $contentService;
         $this->permissionResolver = $permissionResolver;
         $this->userService = $userService;
+
+        parent::__construct();
     }
 
     protected function configure(): void


### PR DESCRIPTION
Closes #14 

Changed constructor execution order as recommended in Symfony documentation: https://symfony.com/doc/current/console.html#configuring-the-command