### PR TITLE
Added compatibility with v3.2

### DIFF
--- a/bundle/Resources/public/admin/js/ezplatformautomatedtranslation.js
+++ b/bundle/Resources/public/admin/js/ezplatformautomatedtranslation.js
@@ -22,8 +22,9 @@ jQuery(function () {
     });
 
     $("form[name=add-translation]").submit(function () {
-        let targetLang = $(".ez-translation__label--selected input[id^=add-translation_language]:checked").val();
-        let sourceLang = $(".ez-translation__label--selected input[id^=add-translation_base_language]:checked").val();
+        let targetLang = $("select[name=add-translation\\[language\\]]").val();
+        let sourceLang = $("select[name=add-translation\\[base_language\\]]").val();
+        console.log(targetLang, sourceLang);
         let mapping = $container.data('languages-mapping');
         let $serviceSelector = $("#add-translation_translatorAlias");
         let serviceAlias = $serviceSelector.val();

--- a/bundle/Resources/public/admin/js/ezplatformautomatedtranslation.js
+++ b/bundle/Resources/public/admin/js/ezplatformautomatedtranslation.js
@@ -24,7 +24,6 @@ jQuery(function () {
     $("form[name=add-translation]").submit(function () {
         let targetLang = $("select[name=add-translation\\[language\\]]").val();
         let sourceLang = $("select[name=add-translation\\[base_language\\]]").val();
-        console.log(targetLang, sourceLang);
         let mapping = $container.data('languages-mapping');
         let $serviceSelector = $("#add-translation_translatorAlias");
         let serviceAlias = $serviceSelector.val();

--- a/bundle/Resources/views/themes/admin/content/modal/add_translation.html.twig
+++ b/bundle/Resources/views/themes/admin/content/modal/add_translation.html.twig
@@ -16,20 +16,33 @@
                 </button>
             </div>
             <div class="modal-body">
-                <span class="ez-translation__title">{{ 'tab.translations.add.language'|trans|desc('Select a language for the new translation') }}</span>
-                {{ form_widget(form.language, {'attr': {'class': 'ez-translation__language-wrapper'}}) }}
-                <span class="ez-translation__title">{{ 'tab.translations.add.base_language'|trans|desc('Base this translation on an existing translation') }}</span>
-                {{ form_widget(form.base_language, {'attr': {'class': 'ez-translation__language-wrapper'}}) }}
+                <div class="ez-translation__title">{{ 'tab.translations.add.language'|trans|desc('Select a language for the new translation') }}</div>
+                {{ form_widget(form.language, {'attr': {'hidden': 'hidden', 'class': 'ez-translation__language-wrapper ez-translation__language-wrapper--language'}}) }}
+                {% include '@ezdesign/ui/component/custom_dropdown.html.twig' with {
+                    choices: form.language.vars.choices,
+                    value: form.language.vars.value,
+                    source_selector: '.ez-translation__language-wrapper--language',
+                    choice_translation_domain: false
+                } %}
+
+                <div class="ez-translation__title mt-4">{{ 'tab.translations.add.base_language'|trans|desc('Base this translation on an existing translation') }}</div>
+                {{ form_widget(form.base_language, {'attr': {'hidden': 'hidden', 'class': 'ez-translation__language-wrapper ez-translation__language-wrapper--base-language'}}) }}
+                {% include '@ezdesign/ui/component/custom_dropdown.html.twig' with {
+                    choices: form.base_language.vars.choices,
+                    value: form.base_language.vars.value,
+                    source_selector: '.ez-translation__language-wrapper--base-language',
+                    choice_translation_domain: false
+                } %}
 
                 {% include '@ezdesign/content/remote_translate_form_fields.html.twig' %}
             </div>
-            <div class="modal-footer justify-content-center">
-                <button type="button" class="btn btn-dark" data-dismiss="modal">
+            <div class="modal-footer">
+                {{ form_widget(form.add, {'attr': {'class': 'btn btn-primary ez-btn--create-translation', 'disabled': 'disabled'}}) }}
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">
                     {{ 'tab.translations.add.cancel'|trans|desc('Cancel') }}
                 </button>
-                {{ form_widget(form.add, {'attr': {'class': 'btn btn-primary ez-btn--wide ez-btn--create-translation', 'disabled': 'disabled'}}) }}
             </div>
-            {{ form_end(form) }}
         </div>
+        {{ form_end(form) }}
     </div>
 </div>


### PR DESCRIPTION
This PR brings compatibility with v3.2 as it was broken due to the design changes. 

Compatibility with v3.0 / v3.1 is kept in branch https://github.com/ezsystems/ezplatform-automated-translation/tree/2.0.

If merged this one should be tagged v2.1.x. 